### PR TITLE
fix: property slug isn't parsed correctly

### DIFF
--- a/exposify.php
+++ b/exposify.php
@@ -47,8 +47,8 @@ function exposify_rewrite()
   $options = get_option('exposify_settings');
   $siteSlug = $options['exposify_site_slug'] ? $options['exposify_site_slug'] : 'immobilien';
   add_rewrite_rule(
-    '^' . $siteSlug . '/([\w\d]+)/?\??(.+)?$',
-    'index.php?page_id=' . get_option('exposify_property_page_id') . '&slug=$matches[1]&$matches[2]',
+    '^' . $siteSlug . '/(.+)/?$',
+    'index.php?page_id=' . get_option('exposify_property_page_id') . '&slug=$matches[1]',
     'top'
   );
   add_rewrite_tag('%slug%', '([^&]+)');


### PR DESCRIPTION
Hier hat sich ein ganz komischer Fehler eingeschlichen min Jung!

Bei einem Immobilienslug wie `zentrale-city-lage-ladenlokal-im-eg-kernsaniert-sehr-modern-renoviert` startet das Wordpress Plugin eine Anfrage an `zentralezentrale`. Habs manuell bei Schumann, Eden und Flair geändert.